### PR TITLE
Using Middleware to generate alert

### DIFF
--- a/src/SweetAlert/ConvertMessagesIntoSweatAlert.php
+++ b/src/SweetAlert/ConvertMessagesIntoSweatAlert.php
@@ -17,29 +17,32 @@ class ConvertMessagesIntoSweatAlert
     public function handle($request, Closure $next)
     {
         if($request->session()->has('success')){
-            Alert::success($request->session()->get('success'), 'Success')->persistent();
+            alert()->success($request->session()->get('success'), 'Success')->persistent();
         }
 
         if($request->session()->has('warning')){
-            Alert::success($request->session()->get('warning'), 'Warning')->persistent();
+            alert()->success($request->session()->get('warning'), 'Warning')->persistent();
         }
 
         if($request->session()->has('info')){
-            Alert::success($request->session()->get('info'), 'Info')->persistent();
+            alert()->success($request->session()->get('info'), 'Info')->persistent();
         }
 
         if($request->session()->has('message')){
-            Alert::success($request->session()->get('message'))->persistent();
+            alert()->success($request->session()->get('message'))->persistent();
         }
 
         if($request->session()->has('basic')){
-            Alert::success($request->session()->get('basic'));
+            alert()->success($request->session()->get('basic'));
         }
 
         if($request->session()->has('errors')){
-            $message = $this->prepareErrors($request->session()->get('errors')->getMessages());
+            $message = $request->session()->get('errors');
+            if(!is_string($message)){
+                $message = $this->prepareErrors($message->getMessages());
+            }
 
-            Alert::error($message, 'Errors')->html()->persistent();
+            alert()->error($message, 'Errors')->html()->persistent();
         }
 
         return $next($request);

--- a/src/SweetAlert/ConvertMessagesIntoSweatAlert.php
+++ b/src/SweetAlert/ConvertMessagesIntoSweatAlert.php
@@ -39,7 +39,7 @@ class ConvertMessagesIntoSweatAlert
         if($request->session()->has('errors')){
             $message = $this->prepareErrors($request->session()->get('errors')->getMessages());
 
-            Alert::error($message, 'Errors')->persistent();
+            Alert::error($message, 'Errors')->html()->persistent();
         }
 
         return $next($request);

--- a/src/SweetAlert/ConvertMessagesIntoSweatAlert.php
+++ b/src/SweetAlert/ConvertMessagesIntoSweatAlert.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace UxWeb\SweetAlert;
+
+use Closure;
+use SweetAlertNotifier as Alert;
+
+class ConvertMessagesIntoSweatAlert
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if($request->session()->has('success')){
+            Alert::success($request->session()->get('success'), 'Success')->persistent();
+        }
+
+        if($request->session()->has('warning')){
+            Alert::success($request->session()->get('warning'), 'Warning')->persistent();
+        }
+
+        if($request->session()->has('info')){
+            Alert::success($request->session()->get('info'), 'Info')->persistent();
+        }
+
+        if($request->session()->has('message')){
+            Alert::success($request->session()->get('message'))->persistent();
+        }
+
+        if($request->session()->has('basic')){
+            Alert::success($request->session()->get('basic'));
+        }
+
+        if($request->session()->has('errors')){
+            $message = $this->prepareErrors($request->session()->get('errors')->getMessages());
+
+            Alert::error($message, 'Errors')->persistent();
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Retrieve the errors from ViewErrorBag
+     *
+     * @param $errors
+     * @return string
+     */
+    private function prepareErrors($errors){
+        $errors = collect($errors);
+
+        return $errors->flatten()->implode('<br />');
+    }
+}
+

--- a/src/SweetAlert/SweetAlertNotifier.php
+++ b/src/SweetAlert/SweetAlertNotifier.php
@@ -20,6 +20,7 @@ class SweetAlertNotifier
         'allowOutsideClick' => true,
         'title'             => '',
         'text'              => '',
+        'html'              => true,
     ];
 
     /**

--- a/src/SweetAlert/SweetAlertNotifier.php
+++ b/src/SweetAlert/SweetAlertNotifier.php
@@ -20,7 +20,6 @@ class SweetAlertNotifier
         'allowOutsideClick' => true,
         'title'             => '',
         'text'              => '',
-        'html'              => true,
     ];
 
     /**


### PR DESCRIPTION
The new middleware generated purpose is to capture all messages from the session, which include: errors, success, info, warning, message, and basic.

So for user just to send the message in the session as usual:

``` php
return redirect('dashboard')->with('success', 'Profile updated!'); 
```

And the middleware will capture this message and convert it to SweatAlert message.

> This will be helpful especially to capture the validation messages using `$this->validate()` method.

``` PHP
$this->validate($request, [
        'title' => 'required|unique:posts|max:255',
        'body' => 'required',
]);
```

Because this method automatically generates the response.

---
# Usage
## With Middleware
### Using middleware groups

First register the middleware in web middleware groups by simply add the middleware class `UxWeb\SweetAlert\ConvertMessagesIntoSweatAlert::class` into the $middlewareGroups of your app/Http/Kernel.php class:

``` php
    protected $middlewareGroups = [
        'web' => [
            \App\Http\Middleware\EncryptCookies::class,
            ...
            \UxWeb\SweetAlert\ConvertMessagesIntoSweatAlert::class,
        ],

        'api' => [
            'throttle:60,1',
        ],
    ];

```

> Ensure to register the middleware within 'web' group only.
### Using route middleware

Or if you would like to assign the middleware to specific routes only, you should add the middleware to `$routeMiddleware` in `app/Http/Kernel.php` file:

``` php
protected $routeMiddleware = [
    'auth' => \App\Http\Middleware\Authenticate::class,
    ....
    'sweetalert' => \UxWeb\SweetAlert\ConvertMessagesIntoSweatAlert::class,
];
```

Next step, Within your controllers, set your return message (using `with()`), send the proper message  and proper type

``` PHP
return redirect('dashboard')->with('success', 'Profile updated!'); 
```

or

``` PHP
return redirect()->back()->with('errors', 'Profile updated!'); 
```
