### PR TITLE
Fixed typo on class and file name ConvertMessagesIntoSweetAlert

### DIFF
--- a/src/SweetAlert/ConvertMessagesIntoSweetAlert.php
+++ b/src/SweetAlert/ConvertMessagesIntoSweetAlert.php
@@ -4,7 +4,7 @@ namespace UxWeb\SweetAlert;
 
 use Closure;
 
-class ConvertMessagesIntoSweatAlert
+class ConvertMessagesIntoSweetAlert
 {
     /**
      * Handle an incoming request.


### PR DESCRIPTION
There is a typo on this class as pointed on issue #55 