### PR TITLE
Fixed #106 deprecated method type()

### DIFF
--- a/src/SweetAlert/SweetAlertNotifier.php
+++ b/src/SweetAlert/SweetAlertNotifier.php
@@ -79,7 +79,7 @@ class SweetAlertNotifier
         }
 
         if (!is_null($icon)) {
-            $this->config['type'] = $icon;
+            $this->config['icon'] = $icon;
         }
 
         $this->flashConfig();


### PR DESCRIPTION
See https://github.com/uxweb/sweet-alert/issues/106